### PR TITLE
`humctl` instead of `curl`

### DIFF
--- a/.github/workflows/close_pr.yaml
+++ b/.github/workflows/close_pr.yaml
@@ -3,13 +3,18 @@ on:
   pull_request:
     types:
       - closed
+env:
+  HUMCTL_VERSION: '0.13.0'
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
+      - uses: humanitec/setup-cli-action@v1
+        with:
+          version: ${{ env.HUMCTL_VERSION }}
       - name: Delete Humanitec Env
         run: |
-            curl -X DELETE \
-            -H "Content-Type: application/json" \
-            -H 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
-            https://api.humanitec.io/orgs/${{ vars.HUMANITEC_ORG }}/apps/${{ vars.APP_NAME }}/envs/pr-${{ github.event.number }}
+          humctl delete env pr-${{ github.event.number }} \
+              --token ${{ secrets.HUMANITEC_TOKEN }} \
+              --org ${{ vars.HUMANITEC_ORG }} \
+              --app ${{ vars.APP_NAME }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,18 +8,16 @@ permissions:
   pull-requests: write
 env:
   ENVIRONMENT: 'development'
-  SCORE_HUMANITEC_VERSION: 0.8.0
+  SCORE_HUMANITEC_VERSION: 0.9.1
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install score-humanitec
-        run: |
-          wget https://github.com/score-spec/score-humanitec/releases/download/${{ env.SCORE_HUMANITEC_VERSION }}/score-humanitec_${{ env.SCORE_HUMANITEC_VERSION }}_linux_amd64.tar.gz
-          tar -xvf score-humanitec_${{ env.SCORE_HUMANITEC_VERSION }}_linux_amd64.tar.gz
-          chmod +x score-humanitec
-          mv score-humanitec /usr/local/bin
+      - uses: score-spec/setup-score@v2
+        with:
+          file: score-humanitec
+          version: ${{ env.SCORE_HUMANITEC_VERSION }}
       - name: Run Score
         run: |
           score-humanitec delta \

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -151,6 +151,7 @@ jobs:
 
           cat pr_message.txt
       - name: Comment PR
+        if: ${{ always() }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: pr_message.txt

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -25,7 +25,7 @@ jobs:
             humctl create environment ${{ env.ENVIRONMENT_ID }} \
               --token ${{ secrets.HUMANITEC_TOKEN }} \
               --org ${{ vars.HUMANITEC_ORG }} \
-              --app ${{ env.APP_NAME }} \
+              --app ${{ vars.APP_NAME }} \
               --name ${{ env.ENVIRONMENT_NAME }} \
               -t ${{ env.ENVIRONMENT_TYPE }} \
               --from ${{ env.BASE_ENVIRONMENT }} \
@@ -54,7 +54,7 @@ jobs:
             CURRENT_STATUS=$(humctl get deployment . -o json \
               --token ${{ secrets.HUMANITEC_TOKEN }} \
               --org ${{ vars.HUMANITEC_ORG }} \
-              --app ${{ env.APP_NAME }} \
+              --app ${{ vars.APP_NAME }} \
               --env ${{ env.ENVIRONMENT_ID }} \
               | jq -r .status.status)
             if [ "$CURRENT_STATUS" = "in progress" ]; then
@@ -79,14 +79,14 @@ jobs:
           DOMAINS=$(humctl get active-resources \
                       --token ${{ secrets.HUMANITEC_TOKEN }} \
                       --org ${{ vars.HUMANITEC_ORG }} \
-                      --app ${{ env.APP_NAME }} \
+                      --app ${{ vars.APP_NAME }} \
                       --env ${{ env.ENVIRONMENT_ID }} -o json \
                       | jq -r '. | map(. | select(.metadata.type == "dns")) | map((.metadata.res_id | split(".") | .[1]) + ": [" + .status.resource.host + "](https://" + .status.resource.host + ")") | join("\n")')
           
           DEPLOYMENT_ERRORS=$(humctl get deployment-error \
               --token ${{ secrets.HUMANITEC_TOKEN }} \
               --org ${{ vars.HUMANITEC_ORG }} \
-              --app ${{ env.APP_NAME }} \
+              --app ${{ vars.APP_NAME }} \
               --env ${{ env.ENVIRONMENT_ID }} -o json)
           if [ "$DEPLOYMENT_ERRORS" = "[]" ]; then
             echo "## Deployment successfully completed for ${{ env.ENVIRONMENT_NAME }}! :tada:" >> pr_message.txt
@@ -132,7 +132,7 @@ jobs:
           humctl diff sets env/${{ env.ENVIRONMENT_ID }} env/${{ env.BASE_ENVIRONMENT }} \
               --token ${{ secrets.HUMANITEC_TOKEN }} \
               --org ${{ vars.HUMANITEC_ORG }} \
-              --app ${{ env.APP_NAME }} -o json >> pr_message.txt
+              --app ${{ vars.APP_NAME }} -o json >> pr_message.txt
           echo "" >> pr_message.txt
           echo '```' >> pr_message.txt
           echo "" >> pr_message.txt

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,8 @@ permissions:
 env:
   BASE_ENVIRONMENT: 'development'
   ENVIRONMENT_TYPE: 'development'
-  SCORE_HUMANITEC_VERSION: 0.8.0
+  SCORE_HUMANITEC_VERSION: 0.9.1
+  HUMCTL_VERSION: '0.13.0'
   ENVIRONMENT_ID: pr-${{ github.event.number }}
   ENVIRONMENT_NAME: PR-${{ github.event.number }}
 jobs:
@@ -16,34 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: humanitec/setup-cli-action@v1
+        with:
+          version: ${{ env.HUMCTL_VERSION }}
       - name: Create Humanitec Env
         run: |
-            # Get deployment ID of the main development environment
-            curl \
-            -H "Content-Type: application/json" \
-            -H 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
-            https://api.humanitec.io/orgs/${{ vars.HUMANITEC_ORG }}/apps/${{ vars.APP_NAME }}/envs/${{ env.BASE_ENVIRONMENT }} \
-            | jq -r ".last_deploy.id" > deploy_id.txt
-
-            # Create a new environment for the PR
-            curl -X POST \
-            -H "Content-Type: application/json" \
-            -H 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
-            https://api.humanitec.io/orgs/${{ vars.HUMANITEC_ORG }}/apps/${{ vars.APP_NAME }}/envs \
-            --data-binary @- << EOF
-            {
-              "from_deploy_id": "$(cat deploy_id.txt)",
-              "id": "${{ env.ENVIRONMENT_ID }}",
-              "name": "${{ env.ENVIRONMENT_NAME }}",
-              "type": "${{ env.ENVIRONMENT_TYPE }}"
-            }
-            EOF
-      - name: Install score-humanitec
-        run: |
-          wget https://github.com/score-spec/score-humanitec/releases/download/${{ env.SCORE_HUMANITEC_VERSION }}/score-humanitec_${{ env.SCORE_HUMANITEC_VERSION }}_linux_amd64.tar.gz
-          tar -xvf score-humanitec_${{ env.SCORE_HUMANITEC_VERSION }}_linux_amd64.tar.gz
-          chmod +x score-humanitec
-          mv score-humanitec /usr/local/bin
+            humctl create environment ${{ env.ENVIRONMENT_ID }} \
+              --token ${{ secrets.HUMANITEC_TOKEN }} \
+              --org ${{ vars.HUMANITEC_ORG }} \
+              --app ${{ env.APP_NAME }} \
+              --name ${{ env.ENVIRONMENT_NAME }} \
+              -t ${{ env.ENVIRONMENT_TYPE }} \
+              --from ${{ env.BASE_ENVIRONMENT }} \
+              || true
+      - uses: score-spec/setup-score@v2
+        with:
+          file: score-humanitec
+          version: ${{ env.SCORE_HUMANITEC_VERSION }}
       - name: Run Score
         run: |
           score-humanitec delta \
@@ -61,30 +51,69 @@ jobs:
           IS_DONE=false
 
           while [ "$IS_DONE" = false ]; do
-            CURRENT_STATUS=$(curl \
-              -H "Content-Type: application/json" \
-              -H 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
-              https://api.humanitec.io/orgs/${{ vars.HUMANITEC_ORG }}/apps/${{ vars.APP_NAME }}/envs/${{ env.ENVIRONMENT_ID }} \
-              | jq -r ".last_deploy.status")
-            
-            INPROGRESS="in progress"
-
-            if [ "$CURRENT_STATUS" = "$INPROGRESS" ]; then
+            CURRENT_STATUS=$(humctl get deployment . -o json \
+              --token ${{ secrets.HUMANITEC_TOKEN }} \
+              --org ${{ vars.HUMANITEC_ORG }} \
+              --app ${{ env.APP_NAME }} \
+              --env ${{ env.ENVIRONMENT_ID }} \
+              | jq -r .status.status)
+            if [ "$CURRENT_STATUS" = "in progress" ]; then
               echo "Deployment still in progress..."
               sleep 1
+            elif [ "$CURRENT_STATUS" = "failed" ]; then
+              echo "Deployment failed!"
+              IS_DONE=true
             else
               echo "Deployment complete!"
               IS_DONE=true
             fi
           done
+          if [ "$CURRENT_STATUS" = "failed" ]; then
+              exit 1
+          fi
       - name: Build Comment Message
+        if: ${{ always() }}
         run: |
           ENV_URL=$(jq -r ".metadata.url" score_output.json)
           DEPLOYMENT_ID=$(jq -r ".id" score_output.json)
-          DOMAINS=$(curl -H "Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}" https://api.humanitec.io/orgs/${{ vars.HUMANITEC_ORG }}/apps/${{ vars.APP_NAME }}/envs/${{ env.ENVIRONMENT_ID }}/resources | jq -r '. | map(. | select(.type == "dns")) | map((.res_id | split(".") | .[1]) + ": [" + .resource.host + "](https://" + .resource.host + ")") | join("\n")')
+          DOMAINS=$(humctl get active-resources \
+                      --token ${{ secrets.HUMANITEC_TOKEN }} \
+                      --org ${{ vars.HUMANITEC_ORG }} \
+                      --app ${{ env.APP_NAME }} \
+                      --env ${{ env.ENVIRONMENT_ID }} -o json \
+                      | jq -r '. | map(. | select(.metadata.type == "dns")) | map((.metadata.res_id | split(".") | .[1]) + ": [" + .status.resource.host + "](https://" + .status.resource.host + ")") | join("\n")')
           
-          echo "## Deployment Complete for ${{ env.ENVIRONMENT_NAME }}! :tada:" >> pr_message.txt
-          echo "" >> pr_message.txt
+          DEPLOYMENT_ERRORS=$(humctl get deployment-error \
+              --token ${{ secrets.HUMANITEC_TOKEN }} \
+              --org ${{ vars.HUMANITEC_ORG }} \
+              --app ${{ env.APP_NAME }} \
+              --env ${{ env.ENVIRONMENT_ID }} -o json)
+          if [ "$DEPLOYMENT_ERRORS" = "[]" ]; then
+            echo "## Deployment successfully completed for ${{ env.ENVIRONMENT_NAME }}! :tada:" >> pr_message.txt
+            echo "" >> pr_message.txt
+          else
+            echo "## Deployment failed for ${{ env.ENVIRONMENT_NAME }}! :x:" >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo "### Errors:" >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo '```json' >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo "$DEPLOYMENT_ERRORS" | jq .[0].status.message -r >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo '```' >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo "<details><summary>Errors details</summary>" >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo "### Errors details:" >> pr_message.txt
+            echo '```json' >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo "$DEPLOYMENT_ERRORS" >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo '```' >> pr_message.txt
+            echo "" >> pr_message.txt
+            echo "</details>" >> pr_message.txt
+            echo "" >> pr_message.txt
+          fi
           
           echo "### [View in Humanitec]($ENV_URL)" >> pr_message.txt
           echo "Deployment ID: $DEPLOYMENT_ID" >> pr_message.txt
@@ -94,6 +123,20 @@ jobs:
           echo "" >> pr_message.txt
           echo "$DOMAINS" >> pr_message.txt
           echo "" >> pr_message.txt
+
+          echo "<details><summary>Deployment diff</summary>" >> pr_message.txt
+          echo "" >> pr_message.txt
+          echo "### Deployment diff:" >> pr_message.txt
+          echo '```json' >> pr_message.txt
+          echo "" >> pr_message.txt
+          humctl diff sets env/${{ env.ENVIRONMENT_ID }} env/${{ env.BASE_ENVIRONMENT }} \
+              --token ${{ secrets.HUMANITEC_TOKEN }} \
+              --org ${{ vars.HUMANITEC_ORG }} \
+              --app ${{ env.APP_NAME }} -o json >> pr_message.txt
+          echo "" >> pr_message.txt
+          echo '```' >> pr_message.txt
+          echo "" >> pr_message.txt
+          echo "</details>" >> pr_message.txt
 
           echo "<details><summary>Score Output</summary>" >> pr_message.txt
           echo "" >> pr_message.txt


### PR DESCRIPTION
Like in there https://github.com/humanitec-architecture/backstage/pull/9:
- `humctl` instead of `curl` in GHA
- `score-humanitec` `0.9.1`
- Handle Deployment failure and errors in PR
- Display diff between 2 Envs in PR

Fixing:
- https://github.com/Humanitec-DemoOrg/ephemeral-env-demo/issues/21
- https://github.com/Humanitec-DemoOrg/ephemeral-env-demo/issues/11